### PR TITLE
Revise README for iOS 26.4 and 18.7.5 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# iOS 26.3 beta 2, iOS 26.2.1 - iOS 18.7.3 & iOS 17.7.2, iOS 16.7.12 Verified Jailbreak Tools, Download, Reviews & Jailbreak Solutions - (iOS 18.1 - iOS 18.8)
+# iOS 26.4 beta 2, iOS 26.3, iOS 26.2 - iOS 18.7.5 & iOS 17.7.2, iOS 16.7.14 Verified Jailbreak Tools, Download, Reviews & Jailbreak Solutions - (iOS 18.1 - iOS 18.8)
 
-Updated iOS 26.3 beta 2, iOS 26.2, iOS 26.1 - iOS 18, 18.1, 18.2, 18.3, 18.4, 18.5, 18.6, 18.7.3 - iOS 17 Jailbreak Methods, Benefits, Status, and Jailbreak Solutions Research Data.
+Updated iOS 26.4 beta 2, iOS 26.3, iOS 26.2, iOS 26.1 - iOS 18, 18.1, 18.2, 18.3, 18.4, 18.5, 18.6, 18.7.5 - iOS 17 Jailbreak Methods, Benefits, Status, and Jailbreak Solutions Research Data.
 
 <meta name="google-site-verification" content="N5fkQW_mArfKg_c68CbB-YfIWX_Fts0dXkJkTQuKUoE"/>
 
-![Jailbreak iOS 26.3 beta 2, iOS 26.2.1, iOS 18, 18.1,18.2,18.3, 18.4, 18.5, 18.7.3 Online - How to Jailbreak 17.8, 16.7.12, 15.8](https://github.com/user-attachments/assets/942ef641-e611-4c6b-a32b-ad8fe61a20d6)
+![Jailbreak iOS 26.4 beta 2, iOS  26.3, iOS 26.2, iOS 18, 18.1,18.2,18.3, 18.4, 18.5, 18.7.5 Online - How to Jailbreak 17.8, 16.7.12, 15.8](https://github.com/user-attachments/assets/942ef641-e611-4c6b-a32b-ad8fe61a20d6)
 
 
 
-## iOS 26.3 beta 4 / iOS 26.2.1 - iOS 18.7.3- iOS 17.7.12 Jailbreak Guide Introduction:
+## iOS 26.4 beta 4 / iOS 26.3 - iOS 18.7.5 - iOS 17.7.12 Jailbreak Guide Introduction:
 
-Apple has released iOS 26.3 beta 2, iOS 26.2.1, and iOS 18.7.3, now available to developers. IOS 26, Apple includes innovative features; users are curious about the possibilities and benefits of jailbreaking their iOS 26 devices, including iOS 17.7.13 and iOS 18.7.3 
+Apple has released iOS 26.4 beta 2, iOS 26.3, and iOS 18.7.5, now available to developers. IOS 26, Apple includes innovative features; users are curious about the possibilities and benefits of jailbreaking their iOS 26 devices, including iOS 17.7.2 and iOS 18.7.5 
 
-This comprehensive guide is based on our research data about iOS versions. It will drive you into iOS 26.3 beta 4 (26.1, iOS 26.2.1), iOS 18.7.3, iOS 17.7.2 (iOS 17, 17.1, 17.2, 17.3, 17.4, 17.5, 17.6 -  iOS 18, iOS 18.1, 18.2, 18.3, 18.4, 18.5, 18.6.1) & beta jailbreaks, discussing its advantages, Alternatives, status, preparation, safety measures, differences between tethered and untethered jailbreaks, best practices, prospects, and FAQs.
+This comprehensive guide is based on our research data about iOS versions. It will drive you into iOS 26.4 beta 4 (26.1, iOS 26.2, 26.3), iOS 18.7.5, iOS 17.7.2 (iOS 17, 17.1, 17.2, 17.3, 17.4, 17.5, 17.6 -  iOS 18, iOS 18.1, 18.2, 18.3, 18.4, 18.5, 18.6.1) & beta jailbreaks, discussing its advantages, Alternatives, status, preparation, safety measures, differences between tethered and untethered jailbreaks, best practices, prospects, and FAQs.
 
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ## Community-Created Solutions for iOS Jailbreaking:
@@ -77,18 +77,18 @@ According to the security content from Apple for iOS 16.2 and iPadOS 16.2, a vul
 | Palera1n           | Yes (very limited)           | Works for certain older devices (A11 and below) on iOS 15 – 17.7(iOS 26 Limited) via Checkm8 exploit; not full modern support  |
 | Checkra1n          | No                           | Checkra1n classic jailbreak does *not* support iOS 26.2; limited/virtual options exist but no native support  |
 
-### Current Compatibility of Jailbreak Solutions Tools for iOS 26 - iOS 26.2 
+### Current Compatibility of Jailbreak Solutions Tools for iOS 26 - iOS 26.4 
 
-| Jailbreak Solutions Tool     | Compatible with iOS 26 - iOS 26.3/26.2.1? | Notes |
+| Jailbreak Solutions Tool     | Compatible with iOS 26 - iOS 26.4/26.3? | Notes |
 |--------------------|------------------------------|-------|
-| Jailbreak Tweak Master  | Yes ✅                           | Version 3.4.2 is supported for iOS 26.3 beta 2 and below. It may be possible to install Cydia Lite and Sileo Lite package managers.|
+| Jailbreak Tweak Master  | Yes ✅                           | Version 3.4.2 is supported for iOS 26.4 beta 2 and below. It may be possible to install Cydia Lite and Sileo Lite package managers.|
 | ZeeStore  | Yes ✅                           | Newly released iOS jailbreak solution tool may allow users to install unc0ver dark, Misakax, Misaka26, Cydia, Sileo package managers, and Live Container (live support).  |
 | Terminal Jailbreak Tool            | Yes ✅                           | Another jailbreak solution tool supports iOS 16.2 and below. Users can install jailbreak-like tweaks, icons, and home screen customizations, as well as repositories.  |
 | misaka26             | 26.1 Yes ✅ / 26.2 NO ❌                        | misaka26. An ultimate customization tool, utilizing the bug that makes TrollRestore possible. iOS /iPadOS 16.0 - 26.1 & 26.2 beta 1. Supported iOS 16.0 ~ 26.1  |
 
 
 
-### iOS 18.7.3 - iOS 18 Jailbreak Status:
+### iOS 18.7.5 - iOS 18 Jailbreak Status:
 
 ### iOS 17.7.13 - iOS 17 Jailbreak Status:
 


### PR DESCRIPTION
Updated the README to reflect the latest iOS versions and jailbreak tools.

iOS 26.4 beta 2, iOS 18.7.5, iOS 17.7.2 and below Jailbreak tools updates